### PR TITLE
Fix curl calls causing errors

### DIFF
--- a/build/rootfs/etc/cont-init.d/50-setup-ikvm.sh
+++ b/build/rootfs/etc/cont-init.d/50-setup-ikvm.sh
@@ -30,6 +30,7 @@ get_launch_jnlp() {
     if curl --fail -sk --cookie-jar "$temp" -XPOST "$url/cgi/login.cgi" \
           --data "name=$KVM_USER&pwd=$KVM_PASS&check=00" -o/dev/null; then
         launch_jnlp=$(curl --fail -sk --cookie "$temp" \
+            --referer "$url/cgi/url_redirect.cgi?url_name=man_ikvm" \
             "$url/cgi/url_redirect.cgi?url_name=man_ikvm&url_type=jwsk")
         test $? -eq 0 && fail=
     fi
@@ -77,7 +78,7 @@ install_ikvm_application() {
     mkdir -p "$destdir"
     cd "$destdir"
     for x in $jar $linuxlibs; do
-        curl -o $x.pack.gz "$codebase$x.pack.gz"
+        curl -ko $x.pack.gz "$codebase$x.pack.gz"
         unpack200 $x.pack.gz $x
     done
     unzip -o liblinux*.jar


### PR DESCRIPTION
This may be due to my BMC/IPMI rev 03.39 which is an older version from 2015. When running I received an error in `50-setup-ikm.sh`

```
[cont-init   ] 50-setup-ikvm.sh: executing...
[cont-init   ] 50-setup-ikvm.sh: terminated with error 22.
```

Curl was receiving a 500 Internal Server Error and silently failing and not able to download the JNLP. When logging into the HTTP site through a browser it looked as though maybe it was due to missing something in the request and after some trial and error I got it working by adding a `Referer` header.

The error I was receiving after the previous fix was it was not able to download the JAR archives because of a certificate error. I don't have a valid cert installed and my guess is most don't either, so I added `-k` to negate the SSL check.

These changes should be non breaking but I can not test on other versions. I have builds pushing to ghcr if you or anyone would like to try these changes out.